### PR TITLE
Implement per-user sessions

### DIFF
--- a/bazaar-tracker-app.yaml
+++ b/bazaar-tracker-app.yaml
@@ -21,6 +21,8 @@ envs:
     scope: RUN_AND_BUILD_TIME
   - key: BUCKET_SECRET
     scope: RUN_AND_BUILD_TIME
+  - key: SESSION_SECRET
+    scope: RUN_AND_BUILD_TIME
 
 ingress:
   rules:


### PR DESCRIPTION
## Summary
- use Starlette `SessionMiddleware` for sessions
- store user ID in session on login
- load user from session in dashboard
- add logout endpoint and environment variable for session secret

## Testing
- `python -m py_compile main.py models.py`


------
https://chatgpt.com/codex/tasks/task_b_6847bb9a09b08332a76ded54bbb9b6b4