### PR TITLE
Move list_of_games inside dashboard page

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,202 +181,6 @@ async def logout_page(request: Request):
     context.session.clear()
     ui.navigate.to('/')
 
-@ui.refreshable
-async def list_of_games(page_number=1, page_size=8, session=None, season=None) -> None:
-    context.session = session or getattr(context, 'session', None)
-    context.season = season if season is not None else getattr(context, 'season', 0)
-    async def delete_game(game_id: int) -> None:
-        # ensure that the game belongs to the current user before deleting
-        user = await get_current_user()
-        game = await models.Game.get_or_none(id=game_id, player=user.id)
-        if not game:
-            ui.notify('Unauthorized', color='negative')
-            return
-        await game.delete()
-        mark_games_changed()
-        list_of_games.refresh(page_number=page_number, session=context.session, season=context.season)
-
-    user = await get_current_user()
-    if not user:
-        ui.label('Not logged in').classes('text-red-500')
-        ui.navigate.to('/')
-        return
-
-    season = context.season
-
-    total_games = await models.Game.filter(player=user.id, season=season).count()
-    games = await models.Game.filter(player=user.id, season=season)\
-        .order_by('-played')\
-        .offset((page_number - 1) * page_size)\
-        .limit(page_size)\
-        .prefetch_related('player')
-
-    total_pages = max((total_games + page_size - 1) // page_size, 1)
-
-    grid_style = (
-        'display: grid; '
-        'grid-template-columns: repeat(9, minmax(100px, 1fr)); '
-        'gap: 0.5rem; align-items: center; width: 100%;'
-    )
-
-    with ui.column().classes('w-full'):
-        if games:
-            with ui.element('div').style(grid_style).classes('font-bold'):
-                for header in ['Player', 'Hero', 'Mode', 'Win/Day', 'Media', 'Upload', 'Notes', 'Played', 'Actions']:
-                    ui.label(header).classes('truncate text-center')
-
-        for game in games:
-            username = game.player.username
-            placement_color = (
-                "text-white" if game.wins == 10 and game.finished == 10 else  # Perfect (Diamon)
-                "text-yellow-400" if game.wins == 10 and game.finished > 10 else    # Gold
-                "text-gray-400" if game.wins >= 7 else                            # Silver
-                "text-[#cd7f32]" if game.wins >= 4 else                           # Bronze
-                "text-gray-500"
-            )
-            hero_colors = {
-                'Dooley': 'bg-[#397d83] text-white',
-                'Mak': 'bg-[#2da337] text-white',
-                'Pygmalien': 'bg-[#f56a1f] text-white',
-                'Vanessa': 'bg-[#6312de] text-white',
-            }
-            hero_class = hero_colors.get(game.hero.lower().capitalize(), 'bg-gray-200 text-gray-900')
-
-            with ui.element('div').style(grid_style):
-                ui.label(username).classes('truncate text-center')
-                ui.label(game.hero).classes(
-                    f'truncate rounded-full px-3 py-1 {hero_class} text-sm font-semibold shadow text-center'
-                )
-                ui.label("Ranked" if game.ranked else "Non-Ranked").classes('truncate text-center')
-                ui.label("Perfect Game" if game.wins == 10 and game.finished == 10 else f"{game.wins}/{game.finished}").classes(
-                    f'truncate {placement_color} text-center')
-                ui.link('View', target=game.media, new_tab=True).classes('text-blue-600 underline text-center') if game.media else ui.label('-').classes('truncate text-center text-gray-500')
-
-                with ui.dialog().props('maximized') as dialog, ui.card().classes('w-full h-full'):
-                    ui.image(game.upload).props('fit=none').classes('mb-4')
-                    ui.button('Close', on_click=dialog.close).classes('mt-2')
-
-                ui.link('View').on('click', lambda d=dialog: d.open()).classes('text-blue-600 underline text-center') if game.upload else ui.label('No Upload').classes('truncate text-gray-500 text-center')
-
-                ui.label(game.notes or '').classes('truncate text-center')
-                played_str = game.played.strftime('%Y-%m-%d %I:%M %p') if game.played else ''
-                ui.label(played_str).classes('truncate text-center')
-                ui.button(icon="delete", on_click=lambda g=game.id: delete_game(g)).props('color=negative flat')
-                ui.separator().classes('col-span-9 my-1')
-
-        # Pagination controls
-        if games:
-            with ui.row().classes('justify-center mt-4'):
-                if page_number > 1:
-                    ui.button('Previous', on_click=lambda: list_of_games.refresh(page_number=page_number - 1, session=context.session, season=context.season))
-                ui.label(f'Page {page_number} of {total_pages}').classes('mt-2')
-                if page_number < total_pages:
-                    ui.button('Next', on_click=lambda: list_of_games.refresh(page_number=page_number + 1, session=context.session, season=context.season))
-    
-    # Placement tally chart for each hero
-
-    # Fetch placement data for the current user and season
-    games_for_chart = await models.Game.filter(player=user.id, season=season).all()
-
-    # Prepare data: {hero: [count of 0 wins, 1 win, ..., 10 wins]}
-    hero_options = ['Dooley', 'Mak', 'Pygmalien', 'Vanessa']
-    placement_counts = {hero: [0]*11 for hero in hero_options}
-
-    for game in games_for_chart:
-        hero = game.hero.lower().capitalize()
-        if hero in placement_counts and 0 <= game.wins <= 10:
-            placement_counts[hero][game.wins] += 1
-
-    # Chart data
-    labels = [str(i) for i in range(11)]
-    datasets = [
-        {
-            "label": hero,
-            "data": placement_counts[hero],
-        }
-        for hero in hero_options
-    ]
-    ui.label('Game Stats').classes('font-bold text-2xl mb-2 text-grey-200 w-full mt-2').style('border-top: 2px solid #444; padding-top: 1rem;')
-    with ui.row().classes('w-full mb-4 gap-4 flex flex-wrap items-start'):
-        # Ranked placement tally
-        with ui.card().classes('w-full sm:w-[48%] min-w-[300px]'):
-
-            placement_categories = ['No Placement', 'Bronze', 'Silver', 'Gold', 'Perfect']
-            placement_counts_by_category = {hero: [0, 0, 0, 0, 0] for hero in hero_options}
-
-            for game in games_for_chart:
-                if not game.ranked:
-                    continue  # Only count ranked games
-                hero = game.hero.lower().capitalize()
-                if hero not in placement_counts_by_category:
-                    continue
-                if game.wins == 10 and game.finished == 10:
-                    placement_counts_by_category[hero][4] += 1  # Perfect
-                elif 8 <= game.wins <= 10 and game.finished > 10:
-                    placement_counts_by_category[hero][3] += 1  # Gold
-                elif 4 <= game.wins <= 7:
-                    placement_counts_by_category[hero][2] += 1  # Silver
-                elif 1 <= game.wins <= 3:
-                    placement_counts_by_category[hero][1] += 1  # Bronze
-                else:
-                    placement_counts_by_category[hero][0] += 1  # No Placement
-
-            columns = [
-                {"name": "placement", "label": "Placement", "field": "placement", "align": "left"},
-            ] + [
-                {"name": hero, "label": hero, "field": hero, "align": "center"}
-                for hero in hero_options
-            ]
-            rows = []
-            for idx, category in enumerate(placement_categories):
-                row = {"placement": category}
-                for hero in hero_options:
-                    row[hero] = placement_counts_by_category[hero][idx]
-                rows.append(row)
-
-            ui.label('Ranked Placement').classes('font-bold mb-2')
-            with ui.element('div').classes('overflow-x-auto w-full'):
-                with ui.table(columns=columns, rows=rows).classes('w-full text-center rounded-lg border border-gray-700'):
-                    pass
-
-        # Unranked placement tally
-        with ui.card().classes('w-full sm:w-[48%] min-w-[300px]'):
-
-            unranked_counts_by_category = {hero: [0, 0, 0, 0, 0] for hero in hero_options}
-
-            for game in games_for_chart:
-                if game.ranked:
-                    continue  # Only count unranked games
-                hero = game.hero.lower().capitalize()
-                if hero not in unranked_counts_by_category:
-                    continue
-                if game.wins == 10 and game.finished == 10:
-                    unranked_counts_by_category[hero][4] += 1  # Perfect
-                elif 8 <= game.wins <= 10 and game.finished > 10:
-                    unranked_counts_by_category[hero][3] += 1  # Gold
-                elif 4 <= game.wins <= 7:
-                    unranked_counts_by_category[hero][2] += 1  # Silver
-                elif 1 <= game.wins <= 3:
-                    unranked_counts_by_category[hero][1] += 1  # Bronze
-                else:
-                    unranked_counts_by_category[hero][0] += 1  # No Placement
-
-            unranked_rows = []
-            for idx, category in enumerate(placement_categories):
-                row = {"placement": category}
-                for hero in hero_options:
-                    row[hero] = unranked_counts_by_category[hero][idx]
-                unranked_rows.append(row)
-
-            ui.label('Unranked Placement').classes('font-bold mb-2')
-            with ui.element('div').classes('overflow-x-auto w-full'):
-                with ui.table(columns=columns, rows=unranked_rows).classes('w-full text-center rounded-lg border border-gray-700'):
-                    pass
-
-        # def update():
-        #     grid.options['rowData'][0]['age'] += 1
-        #     grid.update()
-        
 
 @ui.page('/dashboard/{season_id}')
 async def index(request: Request, season_id: str = None):
@@ -417,6 +221,184 @@ async def index(request: Request, season_id: str = None):
         
     ui.button('Log Out', on_click=lambda: ui.navigate.to('/logout')).classes('absolute top-4 right-4 bg-red-600 text-white px-4 py-2 rounded')
     state = SimpleNamespace(uploaded_url='')
+
+    session_data = request.session
+
+    @ui.refreshable
+    async def list_of_games(page_number: int = 1, page_size: int = 8) -> None:
+        context.session = session_data
+        context.season = season.value
+
+        async def delete_game(game_id: int) -> None:
+            user = await get_current_user()
+            game = await models.Game.get_or_none(id=game_id, player=user.id)
+            if not game:
+                ui.notify('Unauthorized', color='negative')
+                return
+            await game.delete()
+            mark_games_changed()
+            list_of_games.refresh(page_number=page_number)
+
+        user_inner = await get_current_user()
+        if not user_inner:
+            ui.label('Not logged in').classes('text-red-500')
+            ui.navigate.to('/')
+            return
+
+        season_num = season.value
+
+        total_games = await models.Game.filter(player=user_inner.id, season=season_num).count()
+        games = (
+            await models.Game.filter(player=user_inner.id, season=season_num)
+            .order_by('-played')
+            .offset((page_number - 1) * page_size)
+            .limit(page_size)
+            .prefetch_related('player')
+        )
+
+        total_pages = max((total_games + page_size - 1) // page_size, 1)
+
+        grid_style = (
+            'display: grid; '
+            'grid-template-columns: repeat(9, minmax(100px, 1fr)); '
+            'gap: 0.5rem; align-items: center; width: 100%;'
+        )
+
+        with ui.column().classes('w-full'):
+            if games:
+                with ui.element('div').style(grid_style).classes('font-bold'):
+                    for header in ['Player', 'Hero', 'Mode', 'Win/Day', 'Media', 'Upload', 'Notes', 'Played', 'Actions']:
+                        ui.label(header).classes('truncate text-center')
+
+            for game in games:
+                username = game.player.username
+                placement_color = (
+                    "text-white" if game.wins == 10 and game.finished == 10 else
+                    "text-yellow-400" if game.wins == 10 and game.finished > 10 else
+                    "text-gray-400" if game.wins >= 7 else
+                    "text-[#cd7f32]" if game.wins >= 4 else
+                    "text-gray-500"
+                )
+                hero_colors = {
+                    'Dooley': 'bg-[#397d83] text-white',
+                    'Mak': 'bg-[#2da337] text-white',
+                    'Pygmalien': 'bg-[#f56a1f] text-white',
+                    'Vanessa': 'bg-[#6312de] text-white',
+                }
+                hero_class = hero_colors.get(game.hero.lower().capitalize(), 'bg-gray-200 text-gray-900')
+
+                with ui.element('div').style(grid_style):
+                    ui.label(username).classes('truncate text-center')
+                    ui.label(game.hero).classes(
+                        f'truncate rounded-full px-3 py-1 {hero_class} text-sm font-semibold shadow text-center'
+                    )
+                    ui.label("Ranked" if game.ranked else "Non-Ranked").classes('truncate text-center')
+                    ui.label(
+                        "Perfect Game" if game.wins == 10 and game.finished == 10 else f"{game.wins}/{game.finished}"
+                    ).classes(f'truncate {placement_color} text-center')
+                    ui.link('View', target=game.media, new_tab=True).classes('text-blue-600 underline text-center') if game.media else ui.label('-').classes('truncate text-center text-gray-500')
+
+                    with ui.dialog().props('maximized') as dialog, ui.card().classes('w-full h-full'):
+                        ui.image(game.upload).props('fit=none').classes('mb-4')
+                        ui.button('Close', on_click=dialog.close).classes('mt-2')
+
+                    ui.link('View').on('click', lambda d=dialog: d.open()).classes('text-blue-600 underline text-center') if game.upload else ui.label('No Upload').classes('truncate text-gray-500 text-center')
+
+                    ui.label(game.notes or '').classes('truncate text-center')
+                    played_str = game.played.strftime('%Y-%m-%d %I:%M %p') if game.played else ''
+                    ui.label(played_str).classes('truncate text-center')
+                    ui.button(icon="delete", on_click=lambda g=game.id: delete_game(g)).props('color=negative flat')
+                    ui.separator().classes('col-span-9 my-1')
+
+            if games:
+                with ui.row().classes('justify-center mt-4'):
+                    if page_number > 1:
+                        ui.button('Previous', on_click=lambda: list_of_games.refresh(page_number=page_number - 1))
+                    ui.label(f'Page {page_number} of {total_pages}').classes('mt-2')
+                    if page_number < total_pages:
+                        ui.button('Next', on_click=lambda: list_of_games.refresh(page_number=page_number + 1))
+
+        games_for_chart = await models.Game.filter(player=user_inner.id, season=season_num).all()
+        hero_options = ['Dooley', 'Mak', 'Pygmalien', 'Vanessa']
+        placement_counts = {hero: [0] * 11 for hero in hero_options}
+
+        for g in games_for_chart:
+            hero = g.hero.lower().capitalize()
+            if hero in placement_counts and 0 <= g.wins <= 10:
+                placement_counts[hero][g.wins] += 1
+
+        ui.label('Game Stats').classes('font-bold text-2xl mb-2 text-grey-200 w-full mt-2').style('border-top: 2px solid #444; padding-top: 1rem;')
+        with ui.row().classes('w-full mb-4 gap-4 flex flex-wrap items-start'):
+            with ui.card().classes('w-full sm:w-[48%] min-w-[300px]'):
+                placement_categories = ['No Placement', 'Bronze', 'Silver', 'Gold', 'Perfect']
+                placement_counts_by_category = {hero: [0, 0, 0, 0, 0] for hero in hero_options}
+
+                for g in games_for_chart:
+                    if not g.ranked:
+                        continue
+                    hero = g.hero.lower().capitalize()
+                    if hero not in placement_counts_by_category:
+                        continue
+                    if g.wins == 10 and g.finished == 10:
+                        placement_counts_by_category[hero][4] += 1
+                    elif 8 <= g.wins <= 10 and g.finished > 10:
+                        placement_counts_by_category[hero][3] += 1
+                    elif 4 <= g.wins <= 7:
+                        placement_counts_by_category[hero][2] += 1
+                    elif 1 <= g.wins <= 3:
+                        placement_counts_by_category[hero][1] += 1
+                    else:
+                        placement_counts_by_category[hero][0] += 1
+
+                columns = [
+                    {"name": "placement", "label": "Placement", "field": "placement", "align": "left"},
+                ] + [
+                    {"name": h, "label": h, "field": h, "align": "center"}
+                    for h in hero_options
+                ]
+                rows = []
+                for idx, category in enumerate(placement_categories):
+                    row = {"placement": category}
+                    for h in hero_options:
+                        row[h] = placement_counts_by_category[h][idx]
+                    rows.append(row)
+
+                ui.label('Ranked Placement').classes('font-bold mb-2')
+                with ui.element('div').classes('overflow-x-auto w-full'):
+                    with ui.table(columns=columns, rows=rows).classes('w-full text-center rounded-lg border border-gray-700'):
+                        pass
+
+            with ui.card().classes('w-full sm:w-[48%] min-w-[300px]'):
+                unranked_counts_by_category = {hero: [0, 0, 0, 0, 0] for hero in hero_options}
+
+                for g in games_for_chart:
+                    if g.ranked:
+                        continue
+                    hero = g.hero.lower().capitalize()
+                    if hero not in unranked_counts_by_category:
+                        continue
+                    if g.wins == 10 and g.finished == 10:
+                        unranked_counts_by_category[hero][4] += 1
+                    elif 8 <= g.wins <= 10 and g.finished > 10:
+                        unranked_counts_by_category[hero][3] += 1
+                    elif 4 <= g.wins <= 7:
+                        unranked_counts_by_category[hero][2] += 1
+                    elif 1 <= g.wins <= 3:
+                        unranked_counts_by_category[hero][1] += 1
+                    else:
+                        unranked_counts_by_category[hero][0] += 1
+
+                unranked_rows = []
+                for idx, category in enumerate(placement_categories):
+                    row = {"placement": category}
+                    for h in hero_options:
+                        row[h] = unranked_counts_by_category[h][idx]
+                    unranked_rows.append(row)
+
+                ui.label('Unranked Placement').classes('font-bold mb-2')
+                with ui.element('div').classes('overflow-x-auto w-full'):
+                    with ui.table(columns=columns, rows=unranked_rows).classes('w-full text-center rounded-lg border border-gray-700'):
+                        pass
     
     async def handle_upload(e):
 
@@ -475,7 +457,7 @@ async def index(request: Request, season_id: str = None):
         notes.value = ''
         state.uploaded_url = ''
         upload_component.reset()
-        list_of_games.refresh(session=context.session, season=context.season)
+        list_of_games.refresh()
         ui.notify('Run added!')
     
     with ui.column().classes('w-full'):
@@ -563,7 +545,7 @@ async def index(request: Request, season_id: str = None):
             ui.button('Add Run', on_click=create).classes('w-full').props('color=primary')
 
         with ui.column().classes('flex-1'):
-            await list_of_games(session=request.session, season=season.value)
+            await list_of_games()
 
     # automatically refresh the user's data when any run is created or deleted
     session_version = game_data_version
@@ -572,7 +554,7 @@ async def index(request: Request, season_id: str = None):
         nonlocal session_version
         if session_version != game_data_version:
             session_version = game_data_version
-            list_of_games.refresh(session=request.session, season=season.value)
+            list_of_games.refresh()
 
     ui.timer(1.0, refresh_if_needed)
 


### PR DESCRIPTION
## Summary
- turn `list_of_games` into a local closure within the dashboard page
- update refresh calls to use the local version
- remove global `list_of_games` definition

## Testing
- `python3 -m py_compile main.py models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f2f45a7b88332b129ea973916abc7