### PR TITLE
Fix session handling after adding run

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,9 @@ async def list_of_games(page_number=1, page_size=8, session=None, season=None) -
     async def delete_game(game_id: int) -> None:
         # ensure that the game belongs to the current user before deleting
         user = await get_current_user()
+        if not user:
+            ui.notify('Unauthorized', color='negative')
+            return
         game = await models.Game.get_or_none(id=game_id, player=user.id)
         if not game:
             ui.notify('Unauthorized', color='negative')
@@ -380,6 +383,7 @@ async def list_of_games(page_number=1, page_size=8, session=None, season=None) -
 async def index(request: Request, season_id: str = None):
 
     context.session = request.session
+    current_session = request.session
     
     ui.page_title("Bazaar Tracker")
     season_source = season_id or context.query.get('season', '0')
@@ -473,7 +477,7 @@ async def index(request: Request, season_id: str = None):
         notes.value = ''
         state.uploaded_url = ''
         upload_component.reset()
-        list_of_games.refresh(session=context.session, season=season.value)
+        list_of_games.refresh(session=current_session, season=season.value)
         ui.notify('Run added!')
     
     with ui.column().classes('w-full'):
@@ -588,7 +592,7 @@ async def index(request: Request, season_id: str = None):
             ui.button('Add Run', on_click=create).classes('w-full').props('color=primary')
 
         with ui.column().classes('flex-1'):
-            await list_of_games(session=request.session, season=season.value)
+            await list_of_games(session=current_session, season=season.value)
 
     # automatically refresh the user's data when any run is created or deleted
     session_version = game_data_version
@@ -597,7 +601,7 @@ async def index(request: Request, season_id: str = None):
         nonlocal session_version
         if session_version != game_data_version:
             session_version = game_data_version
-            list_of_games.refresh(session=request.session, season=season.value)
+            list_of_games.refresh(session=current_session, season=season.value)
 
     ui.timer(1.0, refresh_if_needed)
 


### PR DESCRIPTION
## Summary
- ensure session context persists after adding a run
- guard delete handler when no user is in session

## Testing
- `python3 -m py_compile main.py models.py`

------
https://chatgpt.com/codex/tasks/task_b_684f32433714833289aed61825a80dad