### PR TITLE
Fix union annotation crash on Python 3.9

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import bcrypt
 import boto3
 import hashlib


### PR DESCRIPTION
## Summary
- fix runtime type annotation errors on Python 3.9 by enabling postponed annotations

## Testing
- `python -m py_compile main.py models.py`

------
https://chatgpt.com/codex/tasks/task_b_684f38eeff2c8332b68a4ac7195da806