### PR TITLE
Align pagination to the right

### DIFF
--- a/main.py
+++ b/main.py
@@ -584,7 +584,7 @@ async def index(request: Request, season_id: str = None):
 
         with ui.column().classes('flex-1'):
             games_container = ui.column().classes('w-full')
-            pagination_row = ui.row().classes('justify-center mt-4')
+            pagination_row = ui.row().classes('justify-end mt-4')
             await list_of_games()
             if games:
                 await stats_tables()


### PR DESCRIPTION
## Summary
- align the pagination row to the right side of the dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f5973ed248332b3f55b49477ebfcb