### PR TITLE
Show stats tables only when runs exist

### DIFF
--- a/main.py
+++ b/main.py
@@ -244,6 +244,7 @@ async def index(request: Request, season_id: str = None):
     page_size = 8
     game_rows = {}
     games_container = None
+    stats_container = None
     pagination_row = None
     page_label = None
     prev_button = None
@@ -463,7 +464,12 @@ async def index(request: Request, season_id: str = None):
 
         @ui.refreshable
         async def stats_tables():
-            
+
+            stats_container.clear()
+            has_data = await models.Game.filter(player_id=user.id, season=season.value).exists()
+            if not has_data:
+                return
+
             ranked_heroes, ranked_stats = await collect_stats(True)
             unranked_heroes, unranked_stats = await collect_stats(False)
 
@@ -494,13 +500,14 @@ async def index(request: Request, season_id: str = None):
                  "Perfect Game": unranked_stats[h]['Perfect Game']} for h in unranked_heroes
             ]
 
-            with ui.row().classes('w-full gap-4'):
-                with ui.column().classes('flex-1'):
-                    ui.label('Ranked Game Stats').classes('text-lg')
-                    ui.table(columns=columns, rows=ranked_rows).classes('w-full')
-                with ui.column().classes('flex-1'):
-                    ui.label('Non-Ranked Game Stats').classes('text-lg')
-                    ui.table(columns=columns, rows=unranked_rows).classes('w-full')
+            with stats_container:
+                with ui.row().classes('w-full gap-4'):
+                    with ui.column().classes('flex-1'):
+                        ui.label('Ranked Game Stats').classes('text-lg')
+                        ui.table(columns=columns, rows=ranked_rows).classes('w-full')
+                    with ui.column().classes('flex-1'):
+                        ui.label('Non-Ranked Game Stats').classes('text-lg')
+                        ui.table(columns=columns, rows=unranked_rows).classes('w-full')
         
     with ui.row().classes('flex w-full gap-4'):
 
@@ -583,6 +590,7 @@ async def index(request: Request, season_id: str = None):
 
         with ui.column().classes('flex-1'):
             games_container = ui.column().classes('w-full')
+            stats_container = ui.column().classes('w-full')
             pagination_row = ui.row().classes('w-full justify-end mt-4')
             await list_of_games()
             await stats_tables()


### PR DESCRIPTION
## Summary
- show stats tables inside a dedicated container
- hide the stats tables when no game data exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f5b64e7c08332a598d4493f4bacb2