### PR TITLE
Move pagination directly below game data

### DIFF
--- a/main.py
+++ b/main.py
@@ -590,8 +590,8 @@ async def index(request: Request, season_id: str = None):
 
         with ui.column().classes('flex-1'):
             games_container = ui.column().classes('w-full')
-            stats_container = ui.column().classes('w-full')
             pagination_row = ui.row().classes('w-full justify-end mt-4')
+            stats_container = ui.column().classes('w-full')
             await list_of_games()
             await stats_tables()
 


### PR DESCRIPTION
## Summary
- reorder layout so pagination sits immediately beneath the run table instead of below the stats charts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f5d20155c83329ca1d4d90e07eb8c