### PR TITLE
Add totals row to game stats tables

### DIFF
--- a/main.py
+++ b/main.py
@@ -500,6 +500,20 @@ async def index(request: Request, season_id: str = None):
                  "Perfect Game": unranked_stats[h]['Perfect Game']} for h in unranked_heroes
             ]
 
+            categories = ["No Placement", "3rd", "2nd", "1st", "Perfect Game"]
+
+            if ranked_rows:
+                totals = {"hero": "Total"}
+                for cat in categories:
+                    totals[cat] = sum(r[cat] for r in ranked_rows)
+                ranked_rows.append(totals)
+
+            if unranked_rows:
+                totals = {"hero": "Total"}
+                for cat in categories:
+                    totals[cat] = sum(r[cat] for r in unranked_rows)
+                unranked_rows.append(totals)
+
             with stats_container:
                 with ui.row().classes('w-full gap-4'):
                     with ui.column().classes('flex-1'):


### PR DESCRIPTION
## Summary
- compute category totals for stats tables
- append a Total row to both ranked and unranked tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f5e4c7f80833295067db8ecbc2496