### PR TITLE
Add placement percentage chart

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,32 @@ def mark_games_changed(user_id: int) -> None:
     game_data_version[user_id] = game_data_version.get(user_id, 0) + 1
 
 
+def categorize_game(game):
+    """Return the placement category for a game."""
+    if game.wins == 10 and game.finished == 10:
+        return 'Perfect Game'
+    if game.wins == 10:
+        return '1st'
+    if game.wins >= 7:
+        return '2nd'
+    if game.wins >= 4:
+        return '3rd'
+    return 'No Placement'
+
+
+async def compute_placement_percentages(user_id: int, season: int):
+    """Compute percentage placement statistics for a user's season."""
+    categories = ["No Placement", "3rd", "2nd", "1st", "Perfect Game"]
+    totals = {c: 0 for c in categories}
+    games = await models.Game.filter(player_id=user_id, season=season)
+    for g in games:
+        cat = categorize_game(g)
+        totals[cat] += 1
+    total_games = sum(totals.values())
+    percentages = [round((totals[c] / total_games) * 100, 2) if total_games else 0.0 for c in categories]
+    return categories, percentages
+
+
 async def delete_game_by_id(game_id: int) -> bool:
     """Delete a game for the current user by id.
 
@@ -440,15 +466,7 @@ async def index(request: Request, season_id: str = None):
             return sorted(all_heroes)
 
         def categorize(game):
-            if game.wins == 10 and game.finished == 10:
-                return 'Perfect Game'
-            if game.wins == 10:
-                return '1st'
-            if game.wins >= 7:
-                return '2nd'
-            if game.wins >= 4:
-                return '3rd'
-            return 'No Placement'
+            return categorize_game(game)
 
         async def collect_stats(rank_value: bool):
             heroes = await get_heroes()
@@ -513,6 +531,28 @@ async def index(request: Request, season_id: str = None):
                 for cat in categories:
                     totals[cat] = sum(r[cat] for r in unranked_rows)
                 unranked_rows.append(totals)
+            categories_p, percentages = await compute_placement_percentages(user.id, season.value)
+            chart_options = {
+                "tooltip": {"trigger": "item"},
+                "legend": {"top": "center", "left": "left", "orient": "vertical"},
+                "series": [
+                    {
+                        "name": "Placement",
+                        "type": "pie",
+                        "radius": ["40%", "70%"],
+                        "avoidLabelOverlap": True,
+                        "label": {
+                            "formatter": "{b}: {d}%",
+                            "position": "outside",
+                        },
+                        "labelLine": {"show": True},
+                        "data": [
+                            {"value": p, "name": c}
+                            for c, p in zip(categories_p, percentages)
+                        ],
+                    }
+                ],
+            }
 
             with stats_container:
                 with ui.row().classes('w-full gap-4'):
@@ -522,6 +562,10 @@ async def index(request: Request, season_id: str = None):
                     with ui.column().classes('flex-1'):
                         ui.label('Non-Ranked Game Stats').classes('text-lg')
                         ui.table(columns=columns, rows=unranked_rows).classes('w-full')
+                with ui.row().classes('w-full mt-4'):
+                    with ui.column().classes('w-1/3'):
+                        ui.label('Placement Averages').classes('text-lg')
+                        ui.echart(options=chart_options).classes('w-full h-64')
         
     with ui.row().classes('flex w-full gap-4'):
 

--- a/tests/test_percentages.py
+++ b/tests/test_percentages.py
@@ -1,0 +1,122 @@
+import importlib
+import os
+import sys
+import types
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def setup_env():
+    sys.modules['bcrypt'] = types.ModuleType('bcrypt')
+    sys.modules['boto3'] = types.ModuleType('boto3')
+    sys.modules['httpx'] = types.ModuleType('httpx')
+    sys.modules['uvicorn'] = types.ModuleType('uvicorn')
+    sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda: None)
+    sys.modules['fastapi'] = types.SimpleNamespace(Request=object)
+    middleware = types.ModuleType('starlette.middleware.sessions')
+    middleware.SessionMiddleware = object
+    sys.modules['starlette.middleware.sessions'] = middleware
+
+    fields = types.ModuleType('tortoise.fields')
+    for name in ['IntField','ForeignKeyField','BooleanField','CharField','TextField','DatetimeField']:
+        setattr(fields, name, lambda *a, **kw: None)
+    models_mod = types.ModuleType('tortoise.models')
+    models_mod.Model = object
+    expressions = types.ModuleType('tortoise.expressions')
+    expressions.Q = object
+    class TortoiseStub:
+        _inited = False
+        async def init(*a, **kw):
+            pass
+        async def generate_schemas(*a, **kw):
+            pass
+        async def close_connections(*a, **kw):
+            pass
+    tortoise_mod = types.ModuleType('tortoise')
+    tortoise_mod.Tortoise = TortoiseStub
+    sys.modules['tortoise'] = tortoise_mod
+    sys.modules['tortoise.fields'] = fields
+    sys.modules['tortoise.models'] = models_mod
+    sys.modules['tortoise.expressions'] = expressions
+
+    class DummyElement:
+        def __call__(self, *a, **kw):
+            return self
+        def __getattr__(self, name):
+            return lambda *a, **kw: self
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            pass
+        def classes(self, *a, **kw):
+            return self
+        def props(self, *a, **kw):
+            return self
+        def style(self, *a, **kw):
+            return self
+        def bind_visibility_from(self, *a, **kw):
+            return self
+        def bind_text_from(self, *a, **kw):
+            return self
+        def on(self, *a, **kw):
+            return self
+        def reset(self):
+            pass
+    class DummyUI(DummyElement):
+        def page(self, path):
+            def decorator(func):
+                return func
+            return decorator
+        def refreshable(self, func):
+            async def wrapper(*args, **kwargs):
+                return await func(*args, **kwargs)
+            wrapper.refresh = lambda *a, **kw: None
+            wrapper.__wrapped__ = func
+            return wrapper
+        def timer(self, *a, **kw):
+            pass
+        def run(self, *a, **kw):
+            pass
+    ui = DummyUI()
+    class DummyApp:
+        def on_startup(self, func):
+            pass
+        def on_shutdown(self, func):
+            pass
+        def add_middleware(self, *a, **kw):
+            pass
+        def post(self, path):
+            def decorator(func):
+                return func
+            return decorator
+    app = DummyApp()
+    context = types.SimpleNamespace()
+    nicegui_mod = types.ModuleType('nicegui')
+    nicegui_mod.app = app
+    nicegui_mod.ui = ui
+    nicegui_mod.context = context
+    sys.modules['nicegui'] = nicegui_mod
+
+
+def test_compute_placement_percentages():
+    setup_env()
+    main = importlib.import_module('main')
+
+    class DummyGame:
+        def __init__(self, wins, finished):
+            self.wins = wins
+            self.finished = finished
+
+    games = [DummyGame(5, 8) for _ in range(3)] + [DummyGame(0, 0) for _ in range(25)]
+
+    async def fake_filter(*a, **kw):
+        return games
+
+    main.models.Game.filter = fake_filter
+
+    cats, percents = asyncio.run(main.compute_placement_percentages(1, 0))
+    result = dict(zip(cats, percents))
+    assert result['3rd'] == 10.71
+    assert result['No Placement'] == 89.29
+    assert all(result[c] == 0 for c in ['2nd', '1st', 'Perfect Game'])


### PR DESCRIPTION
## Summary
- compute placement percentages for each season
- display placement percentage chart under stats tables
- provide helpers for computing data
- test placement percentage calculations
- switch placement chart to pie
- show percentage labels and avoid legend overlap
- set pie chart labels outside with label lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f604898f88332b20a9d7fcf174fa4