### PR TITLE
Update pie chart label styling

### DIFF
--- a/main.py
+++ b/main.py
@@ -545,6 +545,8 @@ async def index(request: Request, season_id: str = None):
                         "label": {
                             "formatter": "{b}: {d}%",
                             "position": "outside",
+                            "color": "#ffffff",
+                            "textBorderWidth": 0,
                         },
                         "labelLine": {"show": True},
 


### PR DESCRIPTION
## Summary
- make the placement pie chart labels white with no border

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6e82e770833284d5066f39907544