### PR TITLE
Fix chart refresh after run deletion

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,6 +97,7 @@ async def delete_game_by_id(game_id: int) -> bool:
         ui.notify('Unauthorized', color='negative')
         return False
     await game.delete()
+    mark_games_changed(user.id)
     return True
 
 


### PR DESCRIPTION
## Summary
- mark a user's game data as changed when deleting a run
- test that deleting a run increments the game data version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855ce1ab1e08332b88a3dc02f48cf5d